### PR TITLE
Untrack and restore kicad files from LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,9 +11,3 @@
 *.stl filter=lfs diff=lfs merge=lfs -text
 *.step filter=lfs diff=lfs merge=lfs -text
 *.FCStd* filter=lfs diff=lfs merge=lfs -text
-
-# Schematics (KiCad)
-*.kicad_pcb filter=lfs diff=lfs merge=lfs -text
-*.pro filter=lfs diff=lfs merge=lfs -text
-*.lib filter=lfs diff=lfs merge=lfs -text
-*.dcm filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Tracking KiCad files with git LFS has only been a source of pain with no real benefits so I'll untrack all KiCad related files and restore their contents to the repository.